### PR TITLE
Add debuginfod url to status page

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -32,6 +32,8 @@ sites:
     url: https://mirror.funami.tech/cachy/
   - name: China Mirror 20GBs
     url: https://mirrors.tuna.tsinghua.edu.cn/cachyos/
+  - name: debuginfod server
+    url: https://debuginfod.cachyos.org
 
 status-website:
   cname: status.cachyos.org


### PR DESCRIPTION
Its down as of writing this, so I wanted to check if its likely already known. Turns out, the status page didn't even track it.

For reference, The URL is officially published here: https://github.com/CachyOS/CachyOS-Settings/blob/master/etc/debuginfod/cachyos.urls#L1